### PR TITLE
merge dscache repo in

### DIFF
--- a/dea/apps/dstiler.py
+++ b/dea/apps/dstiler.py
@@ -1,6 +1,6 @@
 import click
-import dscache
-from dscache.tools.tiling import bin_dataset_stream, bin_by_native_tile, web_gs, extract_native_albers_tile
+from .. import dscache
+from ..dscache.tools.tiling import bin_dataset_stream, bin_by_native_tile, web_gs, extract_native_albers_tile
 from datacube.model import GridSpec
 import datacube.utils.geometry as geom
 

--- a/dea/apps/dstiler.py
+++ b/dea/apps/dstiler.py
@@ -1,0 +1,55 @@
+import click
+import dscache
+from dscache.tools.tiling import bin_dataset_stream, bin_by_native_tile, web_gs, extract_native_albers_tile
+from datacube.model import GridSpec
+import datacube.utils.geometry as geom
+
+
+GS_ALBERS = GridSpec(crs=geom.CRS('EPSG:3577'),
+                     tile_size=(100000.0, 100000.0),
+                     resolution=(-25, 25))
+
+
+@click.command('dstiler')
+@click.option('--native', is_flag=True, help='Use Landsat Path/Row as grouping')
+@click.option('--native-albers', is_flag=True, help='When datasets are in Albers grid already')
+@click.option('--web', type=int, help='Use web map tiling regime at supplied zoom level')
+@click.argument('dbfile', type=str, nargs=1)
+def cli(native, native_albers, web, dbfile):
+    """Add spatial grouping to file db.
+
+    Default grid is Australian Albers (EPSG:3577) with 100k by 100k tiles. But
+    you can also group by Landsat path/row (--native), or Google's map tiling
+    regime (--web zoom_level)
+
+    """
+    cache = dscache.open_rw(dbfile)
+    label = 'Processing {} ({:,d} datasets)'.format(dbfile, cache.count)
+
+    if native:
+        group_key_fmt = 'native/{:03d}{:03d}'
+        binner = bin_by_native_tile
+    elif native_albers:
+        group_key_fmt = 'albers/{:+03d}{:+03d}'
+        binner = lambda dss: bin_by_native_tile(dss, native_tile_id=extract_native_albers_tile)
+    elif web is not None:
+        gs = web_gs(web)
+        group_key_fmt = 'web_' + str(web) + '/{:d}_{:d}'
+        binner = lambda dss: bin_dataset_stream(gs, dss)
+    else:
+        group_key_fmt = 'albers/{:+03d}{:+03d}'
+        binner = lambda dss: bin_dataset_stream(GS_ALBERS, dss)
+
+    with click.progressbar(cache.get_all(), length=cache.count, label=label) as dss:
+        bins = binner(dss)
+
+    click.echo('Total bins: {:d}'.format(len(bins)))
+
+    with click.progressbar(bins.values(), length=len(bins), label='Saving') as groups:
+        for group in groups:
+            k = group_key_fmt.format(*group.idx)
+            cache.put_group(k, group.dss)
+
+
+if __name__ == '__main__':
+    cli()

--- a/dea/apps/slurpy.py
+++ b/dea/apps/slurpy.py
@@ -1,12 +1,12 @@
 import click
-import datacube
-import dscache
-from dscache.tools import db_connect, raw_dataset_stream, mk_raw2ds
-from dscache.tools import dictionary_from_product_list
 from threading import Thread
 import queue
+import datacube
+from .. import dscache
+from ..dscache.tools import db_connect, raw_dataset_stream, mk_raw2ds
+from ..dscache.tools import dictionary_from_product_list
+from ..ppr import qmap
 
-from dea.ppr import qmap
 
 EOS = object()
 

--- a/dea/apps/slurpy.py
+++ b/dea/apps/slurpy.py
@@ -1,0 +1,75 @@
+import click
+import datacube
+import dscache
+from dscache.tools import db_connect, raw_dataset_stream, mk_raw2ds
+from dscache.tools import dictionary_from_product_list
+from threading import Thread
+import queue
+
+from dea.ppr import qmap
+
+EOS = object()
+
+
+@click.command('slurpy')
+@click.option('--env', type=str, help='Datacube environment name')
+@click.argument('output', type=str, nargs=1)
+@click.argument('products', type=str, nargs=-1)
+def cli(env, output, products):
+
+    if len(products) == 0:
+        click.echo('Have to supply at least one product')
+        raise click.Abort()
+
+    dc = datacube.Datacube(env=env)
+    all_prods = {p.name: p
+                 for p in dc.index.products.get_all()}
+
+    for p in products:
+        if p not in all_prods:
+            click.echo('No such product found: %s' % p)
+            raise click.Abort()
+
+    raw2ds = mk_raw2ds(all_prods)
+    click.echo('Training compression dictionary')
+    zdict = dictionary_from_product_list(dc, products, samples_per_product=50)
+    click.echo('..done')
+
+    click.echo('Getting dataset counts')
+    counts = {p.name: count
+              for p, count in dc.index.datasets.count_by_product(product=[p for p in products])}
+
+    n_total = 0
+
+    for p, c in counts.items():
+        click.echo('..{}: {:8,d}'.format(p, c))
+        n_total += c
+
+    # TODO: check for overwrite
+    cache = dscache.create_cache(output, zdict=zdict, truncate=True)
+
+    def db_task(products, conn, q):
+        for p in products:
+            for ds in map(raw2ds, raw_dataset_stream(p, conn)):
+                q.put(ds)
+        q.put(EOS)
+
+    conn = db_connect(cfg=env)
+    q = queue.Queue(maxsize=10_000)
+    db_thread = Thread(target=db_task, args=(products, conn, q))
+    db_thread.start()
+
+    dss = qmap(lambda ds: ds, q, eos_marker=EOS)
+    dss = cache.tee(dss)
+
+    label = 'Processing ({:8,d})'.format(n_total)
+    with click.progressbar(dss, label=label, length=n_total) as dss:
+        for ds in dss:
+            pass
+
+    cache.sync()
+    db_thread.join()
+
+
+if __name__ == '__main__':
+    cli()

--- a/dea/dscache/__init__.py
+++ b/dea/dscache/__init__.py
@@ -1,0 +1,15 @@
+from .dscache import (ds2bytes,
+                      DatasetCache,
+                      key_to_bytes,
+                      train_dictionary,
+                      create_cache,
+                      open_rw,
+                      open_ro)
+
+__all__ = ['ds2bytes',
+           'create_cache',
+           'open_ro',
+           'open_rw',
+           'DatasetCache',
+           'key_to_bytes',
+           'train_dictionary']

--- a/dea/dscache/dscache.py
+++ b/dea/dscache/dscache.py
@@ -1,0 +1,548 @@
+from uuid import UUID
+import json
+import lmdb
+import zstandard
+import operator
+import functools
+import itertools
+import toolz
+from types import SimpleNamespace
+from pathlib import Path
+from datacube.model import Dataset
+
+FORMAT_VERSION = b'0001'
+
+
+def key_to_bytes(k):
+    if isinstance(k, str):
+        return k.encode('utf8')
+    if isinstance(k, UUID):
+        return k.bytes
+    if isinstance(k, bytes):
+        return k
+    if isinstance(k, int):
+        if k.bit_length() < 32:
+            return k.to_bytes(4, 'big')
+        elif k.bit_length() < 128:
+            return k.to_bytes(16, 'big')
+        else:
+            return str(k).decode('utf8')
+    if isinstance(k, tuple):
+        return functools.reduce(operator.add, map(key_to_bytes, k))
+
+    raise ValueError('Key must be one of str|bytes|int|UUID|tuple')
+
+
+def uuids2bytes(uu):
+    bb = bytearray(len(uu)*16)
+    for i, u in enumerate(uu):
+        bb[i*16:(i+1)*16] = u.bytes
+    return bytes(bb)
+
+
+def bytes2uuids(bb):
+    n = len(bb)//16
+    return [UUID(bytes=bb[i*16:(i+1)*16]) for i in range(n)]
+
+
+def prefix_visit(tr, prefix, full_key=False):
+    if isinstance(prefix, str):
+        prefix = prefix.encode('utf8')
+
+    n = len(prefix)
+    cursor = tr.cursor()
+    cursor.set_range(prefix)
+    for k, v in cursor:
+        if len(k) < n or k[:n] != prefix:
+            break
+        yield (k if full_key else k[n:]), v
+
+
+def dict2jsonKV(oo, prefix=None, compressor=None):
+    for k, doc in oo.items():
+        data = json.dumps(doc, separators=(',', ':')).encode('utf8')
+        if compressor is not None:
+            data = compressor.compress(data)
+        if prefix is not None:
+            k = prefix + k
+
+        yield (key_to_bytes(k), data)
+
+
+def jsonKV2dict(kv, decompressor=None):
+    def decode(kv):
+        k, doc = kv
+        if decompressor is not None:
+            doc = decompressor.decompress(doc)
+        return k.decode('utf8'), json.loads(doc)
+
+    return {k: doc for k, doc in map(decode, kv)}
+
+
+def ds2bytes(ds):
+    k = key_to_bytes(ds.id)
+
+    doc = dict(uris=ds.uris,
+               product=ds.type.name,
+               metadata=ds.metadata_doc)
+
+    d = json.dumps(doc, separators=(',', ':')).encode('utf8')
+    return (k, d)
+
+
+def doc2bytes(raw_ds):
+    ''' raw_ds is
+
+        metadata:
+          id: <uuid: string>
+          * other fields*
+        uris: [<uri:string>]
+        product: <string>
+    '''
+    k = UUID(toolz.get_in(['metadata', 'id'], raw_ds)).bytes
+    d = json.dumps(raw_ds, separators=(',', ':')).encode('utf8')
+    return (k, d)
+
+
+def doc2ds(doc, products):
+    p = products.get(doc['product'], None)
+    if p is None:
+        raise ValueError('No product named: %s' % doc['product'])
+    return Dataset(p, doc['metadata'], uris=doc['uris'])
+
+
+def save_products(products, transaction, compressor, overwrite=False):
+    def get_metadata_definitions(products):
+        mm = {}
+        for p in products:
+            m = p.metadata_type
+            if m.name not in mm:
+                mm[m.name] = m.definition
+
+        return mm
+
+    mm = get_metadata_definitions(products.values())
+    products = toolz.valmap(lambda p: p.definition, products)
+
+    for k, d in itertools.chain(dict2jsonKV(mm, 'metadata/', compressor),
+                                dict2jsonKV(products, 'product/', compressor)):
+        transaction.put(k, d, overwrite=overwrite, dupdata=False)
+
+
+def build_dc_product_map(metadata_json, products_json):
+    from datacube.model import metadata_from_doc, DatasetType
+
+    mm = toolz.valmap(metadata_from_doc, metadata_json)
+
+    def mk_product(doc, name):
+        mt = doc.get('metadata_type')
+        if mt is None:
+            raise ValueError('Missing metadata_type key in product definition')
+        metadata = mm.get(mt)
+
+        if metadata is None:
+            raise ValueError('No such metadata %s for product %s' % (mt, name))
+
+        return DatasetType(metadata, doc)
+
+    return {k: mk_product(doc, k) for k, doc in products_json.items()}
+
+
+def train_dictionary(dss, dict_sz=8*1024):
+    def to_bytes(o):
+        if isinstance(o, dict):
+            _, d = doc2bytes(o)
+        else:
+            _, d = ds2bytes(o)
+        return d
+
+    sample = list(map(to_bytes, dss))
+    return zstandard.train_dictionary(dict_sz, sample).as_bytes()
+
+
+class DatasetCache(object):
+    """
+    info:
+       version: 4-bytes
+       zdict: pre-trained compression dictionary, optional
+       product/{name}: json
+       metadata/{name}: json
+
+    udata:
+       arbitrary user data (TODO)
+
+    ds:
+       uuid: compressed(json({product: str,
+                              uris: [str],
+                              metadata: object}))
+    """
+    def __init__(self, state):
+        """ Don't use this directly, use create_cache or open_cache.
+        """
+
+        self._dbs = state.dbs
+        self._comp = state.comp
+        self._decomp = state.decomp
+        self._products = state.products
+
+    def _store_products(self):
+        with self._dbs.main.begin(self._dbs.info, write=True) as tr:
+            save_products(self._products, tr, self._comp)
+
+    def sync(self):
+        if not self.readonly:
+            self._store_products()
+
+    def __del__(self):
+        self.sync()
+
+    @property
+    def readonly(self):
+        return self._comp is None
+
+    @property
+    def products(self):
+        return self._products
+
+    def _ds2kv(self, ds):
+        k, d = ds2bytes(ds)
+        d = self._comp.compress(d)
+        return (k, d)
+
+    def _doc2kv(self, ds_raw):
+        k, d = doc2bytes(ds_raw)
+        d = self._comp.compress(d)
+        return (k, d)
+
+    def _ds_save(self, ds, transaction):
+        if ds.type.name not in self._products:
+            self._products[ds.type.name] = ds.type
+
+        k, v = self._ds2kv(ds)
+        transaction.put(k, v)
+
+    def bulk_save(self, dss):
+        with self._dbs.main.begin(self._dbs.ds, write=True) as tr:
+            for ds in dss:
+                self._ds_save(ds, tr)
+
+    def tee(self, dss, max_transaction_size=10000):
+        """Given a lazy stream of datasets persist them to disk and then pass through
+        for further processing.
+        :dss: stream of datasets
+        :max_transaction_size int: How often to commit results to disk
+        """
+        have_some = True
+
+        while have_some:
+            with self._dbs.main.begin(self._dbs.ds, write=True) as tr:
+                have_some = False
+                for ds in itertools.islice(dss, max_transaction_size):
+                    have_some = True
+                    self._ds_save(ds, tr)
+                    yield ds
+
+        self.sync()
+
+    def bulk_save_raw(self, raw_dss):
+        with self._dbs.main.begin(self._dbs.ds, write=True) as tr:
+            for raw_ds in raw_dss:
+                k, v = self._doc2kv(raw_ds)
+                tr.put(k, v)
+
+    def put_group(self, name, uuids):
+        """ Group is a named list of uuids
+        """
+        data = uuids2bytes(uuids)
+        k = key_to_bytes(name)
+
+        with self._dbs.main.begin(self._dbs.groups, write=True) as tr:
+            tr.put(k, data)
+
+    def _get_group_raw(self, name):
+        k = key_to_bytes(name)
+
+        with self._dbs.main.begin(self._dbs.groups, write=False) as tr:
+            return tr.get(k)
+
+    def get_group(self, name):
+        """ Group is a named list of uuids
+        """
+        data = self._get_group_raw(key_to_bytes(name))
+        return bytes2uuids(data) if data is not None else None
+
+    def groups(self, raw=False, prefix=None):
+        """Get list of tuples (group_name, group_size).
+
+        :raw bool: Normally names are returned as strings, supplying raw=True
+        would return bytes instead, this is needed if you are using group names
+        that are not strings, like integers or tuples of basic types.
+
+        :prefix str|bytes: Only report groups with name starting with prefix
+        """
+
+        assert isinstance(prefix, (str, bytes, type(None)))
+
+        def _raw(prefix):
+            with self._dbs.main.begin(self._dbs.groups, write=False, buffers=True) as tr:
+                cursor = tr.cursor() if prefix is None else prefix_visit(tr, prefix, full_key=True)
+                return [(bytes(k), len(d)//16) for k, d in cursor]
+
+        if prefix is not None:
+            prefix = key_to_bytes(prefix)
+
+        nn = _raw(prefix)
+        return nn if raw else [(n.decode('utf8'), c) for n, c in nn]
+
+    def _extract_ds(self, d):
+        d = self._decomp.decompress(d)
+        doc = json.loads(d)
+        return doc2ds(doc, self._products)
+
+    def get(self, uuid):
+        """Extract single dataset with a given uuid, or return None if not found"""
+        if isinstance(uuid, str):
+            uuid = UUID(uuid)
+
+        key = key_to_bytes(uuid)
+
+        with self._dbs.main.begin(self._dbs.ds, buffers=True) as tr:
+            d = tr.get(key, None)
+            if d is None:
+                return None
+
+            return self._extract_ds(d)
+
+    def get_all(self):
+        with self._dbs.main.begin(self._dbs.ds, buffers=True) as tr:
+            for _, d in tr.cursor():
+                yield self._extract_ds(d)
+
+    def stream_group(self, group_name):
+        uu = self._get_group_raw(group_name)
+        if uu is None:
+            raise ValueError('No such group: %s' % group_name)
+
+        if len(uu) & 0xF:
+            raise ValueError('Wrong data size for group %s' % group_name)
+
+        with self._dbs.main.begin(self._dbs.ds, buffers=True) as tr:
+            for i in range(0, len(uu), 16):
+                key = uu[i:i+16]
+                d = tr.get(key, None)
+                if d is None:
+                    raise ValueError('Missing dataset for %s' % (str(UUID(bytes=key))))
+
+                yield self._extract_ds(d)
+
+    @property
+    def count(self):
+        with self._dbs.main.begin(self._dbs.ds) as tr:
+            return tr.stat()['entries']
+
+
+def maybe_delete_db(path):
+    path = Path(path)
+    if not path.exists():
+        return False
+
+    if path.is_dir():
+        db, lock = [path/n for n in ["data.mdb", "lock.mdb"]]
+    else:
+        db = path
+        lock = Path(str(path)+'-lock')
+
+    if db.exists() and lock.exists():
+        db.unlink()
+        lock.unlink()
+
+        if path.is_dir():
+            path.rmdir()
+
+    return True
+
+
+def _from_existing_db(db, products=None, complevel=6):
+    readonly = db.flags().get('readonly')
+
+    try:
+        db_info = db.open_db(b'info', create=False)
+    except lmdb.NotFoundError:
+        raise ValueError('Existing database is not a ds cache')
+
+    with db.begin(db_info, write=False) as tr:
+        version = tr.get(b'version', None)
+        if version is None:
+            raise ValueError('Missing format version field')
+        if version != FORMAT_VERSION:
+            raise ValueError("Unsupported on disk version: " + version.decode('utf8'))
+
+        zdict = tr.get(b'zdict', None)
+
+    dbs = SimpleNamespace(main=db,
+                          info=db_info,
+                          groups=db.open_db(b'groups', create=False),
+                          ds=db.open_db(b'ds', create=False),
+                          udata=db.open_db(b'udata', create=False))
+
+    comp_params = {'dict_data': zstandard.ZstdCompressionDict(zdict)} if zdict else {}
+
+    comp = None if readonly else zstandard.ZstdCompressor(level=complevel, **comp_params)
+    decomp = zstandard.ZstdDecompressor(**comp_params)
+
+    if products is None:
+        with db.begin(db_info, write=False) as tr:
+            metadata = jsonKV2dict(prefix_visit(tr, 'metadata/'), decomp)
+            products = jsonKV2dict(prefix_visit(tr, 'product/'), decomp)
+
+        products = build_dc_product_map(metadata, products)
+
+    state = SimpleNamespace(dbs=dbs,
+                            comp=comp,
+                            decomp=decomp,
+                            products=products)
+
+    return DatasetCache(state)
+
+
+def _from_empty_db(db,
+                   complevel=6,
+                   zdict=None):
+    assert isinstance(zdict, (bytes, type(None)))
+
+    db_info = db.open_db(b'info', create=True)
+
+    with db.begin(db_info, write=True) as tr:
+        tr.put(b'version', FORMAT_VERSION)
+
+        if zdict is not None:
+            tr.put(b'zdict', zdict)
+
+    dbs = SimpleNamespace(main=db,
+                          info=db_info,
+                          groups=db.open_db(b'groups', create=True),
+                          ds=db.open_db(b'ds', create=True),
+                          udata=db.open_db(b'udata', create=True))
+
+    comp_params = {'dict_data': zstandard.ZstdCompressionDict(zdict)} if zdict else {}
+
+    comp = zstandard.ZstdCompressor(level=complevel, **comp_params)
+    decomp = zstandard.ZstdDecompressor(**comp_params)
+
+    state = SimpleNamespace(dbs=dbs,
+                            comp=comp,
+                            decomp=decomp,
+                            products={})
+
+    return DatasetCache(state)
+
+
+def open_ro(path,
+            products=None,
+            lock=False):
+    """Open existing database in readonly mode.
+
+    NOTE: default mode assumes db file is static (not being modified
+    externally), if this is not the case, supply `lock=True` parameter.
+
+    :path str: Path to the db could be folder or actual file
+
+    :products: Override product dictionary with compatible products loaded from
+    the datacube database, this is generally only needed if you intend to add
+    datasets to the datacube index directly (i.e. without product matching
+    metadata documents).
+
+    :lock bool: Supply True if external process is changing DB concurrently.
+
+    """
+
+    subdir = Path(path).is_dir()
+
+    db = lmdb.open(path,
+                   subdir=subdir,
+                   max_dbs=8,
+                   lock=lock,
+                   create=False,
+                   readonly=True)
+
+    return _from_existing_db(db, products=products)
+
+
+def open_rw(path,
+            products=None,
+            max_db_sz=None,
+            complevel=6):
+    """Open existing database in append mode.
+
+    :path str: Path to the db could be folder or actual file
+
+    :products: Override product dictionary with compatible products loaded from
+    the datacube database, this is generally only needed if you intend to add
+    datasets to the datacube index directly (i.e. without product matching
+    metadata documents).
+
+    :max_db_sz int: Maximum size in bytes database file is allowed to grow to, defaults to 10Gb
+
+    :complevel: Compression level (Zstandard) to use when storing datasets, 1
+    fastest, 6 good and still fast, 20+ best but slower.
+    """
+
+    subdir = Path(path).is_dir()
+
+    if max_db_sz is None:
+        max_db_sz = 10*(1 << 30)
+
+    db = lmdb.open(path,
+                   subdir=subdir,
+                   max_dbs=8,
+                   map_size=max_db_sz,
+                   lock=True,
+                   create=False,
+                   readonly=False)
+
+    return _from_existing_db(db, products=products, complevel=complevel)
+
+
+def create_cache(path,
+                 complevel=6,
+                 zdict=None,
+                 max_db_sz=None,
+                 truncate=False):
+    """
+    """
+
+    if truncate:
+        maybe_delete_db(path)
+
+    if max_db_sz is None:
+        max_db_sz = 10*(1 << 30)
+
+    db = lmdb.open(path,
+                   max_dbs=8,
+                   map_size=max_db_sz,
+                   create=True,
+                   readonly=False)
+
+    # If db is not empty just call open on it
+    if db.stat()['entries'] > 0:
+        return _from_existing_db(db, complevel=complevel)
+    else:
+        return _from_empty_db(db, complevel=complevel, zdict=zdict)
+
+
+def test_key_to_value():
+
+    for k in ("string", 217987, 215781587158712587, ("AAA", 3)):
+        bb = key_to_bytes(k)
+        assert isinstance(bb, bytes)
+
+    assert key_to_bytes(UUID(bytes=b"0123456789ABCDEF")) == b"0123456789ABCDEF"
+    assert key_to_bytes(b"88") == b"88"
+
+
+def test_create_cache():
+    ss = create_cache('tmp.lmdb', truncate=True)
+    print(ss)
+    del ss
+    ss = open_ro('tmp.lmdb')
+    print(ss)

--- a/dea/dscache/tools/__init__.py
+++ b/dea/dscache/tools/__init__.py
@@ -1,0 +1,119 @@
+"""
+"""
+import random
+from .. import train_dictionary
+
+
+def dictionary_from_product_list(dc,
+                                 products,
+                                 samples_per_product=10,
+                                 dict_sz=8 * 1024):
+
+    if isinstance(products, str):
+        products = [products]
+
+    limit = samples_per_product * 10
+
+    samples = []
+    for p in products:
+        dss = dc.find_datasets(product=p, limit=limit)
+        random.shuffle(dss)
+        samples.extend(dss[:samples_per_product])
+
+    return train_dictionary(samples, dict_sz)
+
+
+def db_connect(cfg=None):
+    from datacube.config import LocalConfig
+    import psycopg2
+
+    if isinstance(cfg, str) or cfg is None:
+        cfg = LocalConfig.find(env=cfg)
+
+    cfg_remap = dict(dbname='db_database',
+                     user='db_username',
+                     password='db_password',
+                     host='db_hostname',
+                     port='db_port')
+
+    pg_cfg = {k: cfg.get(cfg_name, None)
+              for k, cfg_name in cfg_remap.items()}
+
+    return psycopg2.connect(**pg_cfg)
+
+
+def mk_raw2ds(products):
+    from datacube.model import Dataset
+
+    def raw2ds(ds):
+        product = products.get(ds['product'], None)
+        if product is None:
+            raise ValueError('Missing product {}'.format(ds['product']))
+        return Dataset(product, ds['metadata'], uris=ds['uris'])
+    return raw2ds
+
+
+def raw_dataset_stream(product, db, read_chunk=100, limit=None):
+    assert isinstance(limit, (int, type(None)))
+
+    if isinstance(db, str) or db is None:
+        db = db_connect(db)
+
+    query = '''
+select
+jsonb_build_object(
+  'product', %(product)s,
+  'uris', array((select _loc_.uri_scheme ||':'||_loc_.uri_body
+                 from agdc.dataset_location as _loc_
+                 where _loc_.dataset_ref = agdc.dataset.id and _loc_.archived is null
+                 order by _loc_.added desc, _loc_.id desc)),
+  'metadata', metadata) as dataset
+from agdc.dataset
+where archived is null
+and dataset_type_ref = (select id from agdc.dataset_type where name = %(product)s)
+{limit};
+'''.format(limit='LIMIT {:d}'.format(limit) if limit else '')
+
+    cur = db.cursor(name='c{:04X}'.format(random.randint(0, 0xFFFF)))
+    cur.execute(query, dict(product=product))
+
+    while True:
+        chunk = cur.fetchmany(read_chunk)
+        if not chunk:
+            break
+
+        for (ds,) in chunk:
+            yield ds
+
+    cur.close()
+
+
+class DcTileExtract(object):
+    """ Construct ``datacube.api.grid_workflow.Tile`` object from dataset cache.
+    """
+
+    def __init__(self, cache,
+                 group_by='time',
+                 key_fmt=None,
+                 grid_spec=None):
+        from datacube.api.query import query_group_by
+        from .dstiler import GS_ALBERS
+
+        self._cache = cache
+        self._grouper = query_group_by(group_by=group_by)
+        self._grid_spec = GS_ALBERS if grid_spec is None else grid_spec
+        self._key_fmt = 'albers/{:+03d}{:+03d}' if key_fmt is None else key_fmt
+
+    def __call__(self, tile_idx, _y=None):
+        from datacube import Datacube
+        from datacube.api.grid_workflow import Tile
+
+        if _y is not None:
+            tile_idx = (tile_idx, _y)
+
+        k = self._key_fmt.format(*tile_idx)
+        dss = list(self._cache.stream_group(k))
+
+        geobox = self._grid_spec.tile_geobox(tile_idx)
+        sources = Datacube.group_datasets(dss, self._grouper)
+        return Tile(sources, geobox)

--- a/dea/dscache/tools/profiling.py
+++ b/dea/dscache/tools/profiling.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+import timeit
+
+
+def _rr2s(r):
+    return '''
+Count: {r.count:,d}
+       {fps:.1f} per second
+Total: {r.total:6.3f} sec
+TTFB : {r.ttfb:6.3f} sec
+.....: {r.uu:032X}
+..
+'''.format(r=r, fps=r.count/r.total).strip()
+
+
+def ds_stream_test_func(dss, get_uuid=None):
+    def default_get_uuid(ds):
+        return ds.id
+
+    if get_uuid is None:
+        get_uuid = default_get_uuid
+
+    timer = timeit.default_timer
+    uu = 0
+    count = 0
+    t00 = timer()
+    t0 = None
+    for ds in dss:
+        t0 = t0 or timer()
+        uu ^= get_uuid(ds).int
+        count += 1
+
+    t_end = timer()
+
+    rr = SimpleNamespace(uu=uu,
+                         count=count,
+                         ttfb=t0-t00,
+                         total=t_end-t00,
+                         text='')
+    rr.text = _rr2s(rr)
+    return rr

--- a/dea/dscache/tools/tiling.py
+++ b/dea/dscache/tools/tiling.py
@@ -1,0 +1,120 @@
+from types import SimpleNamespace
+import toolz
+
+
+def web_gs(zoom, tile_size=256):
+    """ Construct grid spec compatible with TerriaJS requests at a given level.
+
+    Tile indexes should be the same as google maps, except that Y component is negative,
+    this is a limitation of GridSpec class, you can not have tile index direction be
+    different from axis direction, but this is what google indexing is using.
+
+    http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/
+    """
+    from datacube.utils.geometry import CRS
+    from datacube.model import GridSpec
+    from math import pi
+
+    R = 6378137
+
+    origin = pi * R
+    res0 = 2 * pi * R / tile_size
+    res = res0*(2**(-zoom))
+    tsz = 2 * pi * R * (2**(-zoom))  # res*tile_size
+
+    return GridSpec(crs=CRS('epsg:3857'),
+                    tile_size=(tsz, tsz),
+                    resolution=(-res, res),        # Y,X
+                    origin=(origin-tsz, -origin))  # Y,X
+
+
+def extract_native_albers_tile(ds, tile_size=100_000):
+    ll = toolz.get_in('grid_spatial.projection.geo_ref_points.ll'.split('.'),
+                      ds.metadata_doc)
+    return tuple(int(ll[k]/tile_size) for k in ('x', 'y'))
+
+
+def extract_ls_path_row(ds):
+    full_id = ds.metadata_doc.get('tile_id')
+
+    if full_id is None:
+        full_id = toolz.get_in(['usgs', 'scene_id'], ds.metadata_doc)
+
+    if full_id is None:
+        return None
+    return tuple(int(s) for s in (full_id[3:6], full_id[6:9]))
+
+
+def bin_dataset_stream(gridspec, dss, persist=None):
+    """
+
+    :param gridspec: GridSpec
+    :param dss: Sequence of datasets (can be lazy)
+    :param persist: Dataset -> SomeThing mapping, defaults to keeping dataset id only
+    """
+    cells = {}
+    geobox_cache = {}
+
+    def default_persist(ds):
+        return ds.id
+
+    def register(tile, geobox, val):
+        cell = cells.get(tile)
+        if cell is None:
+            cells[tile] = SimpleNamespace(geobox=geobox, idx=tile, dss=[val])
+        else:
+            cell.dss.append(val)
+
+    if persist is None:
+        persist = default_persist
+
+    for ds in dss:
+        ds_val = persist(ds)
+
+        if ds.extent is None:
+            print('WARNING: Datasets without extent info: %s' % str(ds.id))
+            continue
+
+        for tile, geobox in gridspec.tiles_from_geopolygon(ds.extent, geobox_cache=geobox_cache):
+            register(tile, geobox, ds_val)
+
+    return cells
+
+
+def bin_by_native_tile(dss, persist=None, native_tile_id=None):
+    """Group datasets by native tiling, like path/row for Landsat.
+
+    :param dss: Sequence of datasets (can be lazy)
+
+    :param persist: Dataset -> SomeThing mapping, defaults to keeping dataset
+    id only
+
+    :param native_tile_id: Dataset -> Key, defaults to extracting `path,row`
+    tuple from metadata's `tile_id` field, but could be anything, only
+    constraint is that Key value can be used as index to python dict.
+    """
+
+    cells = {}
+
+    def default_persist(ds):
+        return ds.id
+
+    def register(tile, val):
+        cell = cells.get(tile)
+        if cell is None:
+            cells[tile] = SimpleNamespace(idx=tile, dss=[val])
+        else:
+            cell.dss.append(val)
+
+    native_tile_id = native_tile_id or extract_ls_path_row
+    persist = persist or default_persist
+
+    for ds in dss:
+        ds_val = persist(ds)
+        tile = native_tile_id(ds)
+        if tile is None:
+            raise ValueError('Missing tile id')
+        else:
+            register(tile, ds_val)
+
+    return cells

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
                       'numpy',
                       'rasterio>=1.0.4',
                       'toolz',
+                      'zstandard',
+                      'lmdb',
                       ],
     tests_require=['pytest'],
     extras_require=dict(async=[
@@ -29,6 +31,8 @@ setup(
             's3-to-tar = dea.apps.s3_to_tar:cli',
             'dc-index-from-json = dea.apps.index_from_json:cli',
             'dc-index-from-tar = dea.apps.index_from_tar:cli',
+            'slurpy = dea.apps.slurpy:cli',
+            'dstiler = dea.apps.dstiler:cli',
         ]
     }
 )


### PR DESCRIPTION
Dataset cache

- uses lmdb as a out-of-core storage of dataset objects
- zstandard compression
- random access
- support for groups (spatial tiling)
- `slurpy` cli app can import from datacube db
- `dstiler` cli app groups datasets based on spatial relations (like `GridWorkFlow`)