### PR TITLE
gs-to-tar preserves directory structure, make logs docker friendly

### DIFF
--- a/dea/apps/gs_to_tar.py
+++ b/dea/apps/gs_to_tar.py
@@ -1,6 +1,7 @@
 import os
 import tarfile
 import click
+import shutil
 from google.cloud import storage
 
 @click.command('gs-to-tar')
@@ -42,19 +43,24 @@ def cli(bucket,
     for yaml in files:
 
         count = str(file_num)
-        filename = "{0}.yaml".format(count)
+        filename = "{bucket}/{filepath}.yaml".format(bucket=bucket, filepath=yaml.name)
 
+        #ensure dir exists
+        if not os.path.exists(os.path.dirname('./' + filename)):
+            os.makedirs(os.path.dirname('./' + filename))
         #download to tar
         yaml.download_to_filename(filename=filename, client=client)
         tar.add(filename)
-        os.remove(filename)
+        os.remove('./' + filename)
 
         #counter
-        print("{count}/{file_count} Downloaded".format(count=count, file_count=file_count),
-              end="\r", flush=True)
+        print("{count}/{file_count} Downloaded".format(count=count, file_count=file_count))
         file_num += 1
 
     tar.close()
+    # Deletes the directory recursively
+    shutil.rmtree("./" + bucket)
+
     print("Done!")
 
 if __name__ == '__main__':

--- a/dea/apps/index_from_tar.py
+++ b/dea/apps/index_from_tar.py
@@ -42,7 +42,7 @@ def from_tar_file(tarfname, index, mk_uri, mode, **kwargs):
               is_flag=True, default=False)
 @click.option('--gzip', is_flag=True, help='Input is compressed with gzip (needed when reading from stdin)')
 @click.option('--xz', is_flag=True, help='Input is compressed with xz (needed when reading from stdin)')
-@click.option('--protocol', type=str, default='s3', help='Override the protocol for working with data in other environments, i.e gs')
+@click.option('--protocol', type=str, default='s3', show_default=True, help='Override the protocol for working with data in other environments, i.e gs')
 @click.argument('input_fname', type=str, nargs=-1)
 def cli(input_fname,
         env,
@@ -55,6 +55,9 @@ def cli(input_fname,
         xz,
         protocol):
 
+    # Ensure :// is present in prefix
+    prefix = protocol.rstrip('://') + '://'
+
     ds_resolve_args = dict(products=product_names,
                            exclude_products=exclude_product_names,
                            fail_on_missing_lineage=not auto_add_lineage,
@@ -64,16 +67,14 @@ def cli(input_fname,
     if ignore_lineage:
         auto_add_lineage = False
 
-    def mk_s3_uri(name):
-        if not protocol.endswith('://'):
-            protocol = protocol + '://'
-        return protocol + name
+    def mk_uri(name):
+        return prefix + name
 
     def report_error(msg):
         print(msg, file=sys.stderr)
 
     def process_file(filename, index, fps, mode=None, n_failed=0):
-        for ds, err in from_tar_file(filename, index, mk_s3_uri, mode=mode, **ds_resolve_args):
+        for ds, err in from_tar_file(filename, index, mk_uri, mode=mode, **ds_resolve_args):
             if ds is not None:
                 try:
                     index.datasets.add(ds, with_lineage=auto_add_lineage)


### PR DESCRIPTION
Preserves directory structure so files will be in `gs://bucket/filepath.yaml` format when loaded using dc-index-from-tar.

Modify how logs are written as flushed logs don't show up in docker orchestration tools (such as kubernetes)

