### PR TITLE
Metadata export - change dataset time to center time

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/export_md.py
+++ b/apps/dc_tools/odc/apps/dc_tools/export_md.py
@@ -280,7 +280,7 @@ def get_properties(dataset, property_offsets=None):
     }
     """
     props = dict()
-    props['datetime'] = [dataset.time.begin, dataset.time.end]
+    props['datetime'] = dataset.center_time
     props['odc:processing_datetime'] = dataset.indexed_time
 
     return {'properties': props}


### PR DESCRIPTION
Just change dataset time to a single timestamp - `center_time`