### PR TITLE
Add EO3 support for dc-index-from-tar

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/index_from_tar.py
+++ b/apps/dc_tools/odc/apps/dc_tools/index_from_tar.py
@@ -74,6 +74,8 @@ def cli(input_fname,
 
     # Ensure :// is present in prefix
     prefix = protocol.rstrip('://') + '://'
+    if prefix.startswith('file'):
+        prefix = prefix + '/'
 
     ds_resolve_args = dict(products=product_names,
                            exclude_products=exclude_product_names,

--- a/libs/index/odc/index/__init__.py
+++ b/libs/index/odc/index/__init__.py
@@ -12,6 +12,11 @@ from . _index import (
     ordered_dss,
 )
 
+from ._eo3 import (
+    eo3_lonlat_bbox,
+    eo3_grid_spatial,
+)
+
 __all__ = (
     "from_yaml_doc_stream",
     "from_metadata_stream",
@@ -21,4 +26,6 @@ __all__ = (
     "chop_query_by_time",
     "time_range",
     "ordered_dss",
+    "eo3_lonlat_bbox",
+    "eo3_grid_spatial",
 )

--- a/libs/index/odc/index/_eo3.py
+++ b/libs/index/odc/index/_eo3.py
@@ -1,0 +1,81 @@
+from affine import Affine
+from datacube.utils.geometry import (
+    CRS,
+    Geometry,
+    polygon_from_transform,
+    bbox_union,
+)
+
+
+def grid2points(grid):
+    h, w = grid['shape']
+    transform = Affine(*grid['transform'][:6])
+    pts = [(0, 0), (w, 0), (w, h), (0, h)]
+    return [transform*pt for pt in pts]
+
+
+def grid2ref_points(grid):
+    nn = ['ul', 'ur', 'lr', 'll']
+    return {n: dict(x=x, y=y)
+            for n, (x, y) in zip(nn, grid2points(grid))}
+
+
+def grid2polygon(grid, crs):
+    h, w = grid['shape']
+    transform = Affine(*grid['transform'][:6])
+
+    if isinstance(crs, str):
+        crs = CRS(crs)
+
+    return polygon_from_transform(w, h, transform, crs)
+
+
+def eo3_lonlat_bbox(doc, tol=0.001):
+    epsg4326 = CRS('epsg:4326')
+    crs = CRS(doc['crs'])
+    grids = doc['grids']
+    geometry = doc.get('geometry')
+    if geometry is None:
+        return bbox_union(grid2polygon(grid, crs).to_crs(epsg4326, tol).boundingbox
+                          for grid in grids.values())
+    else:
+        return Geometry(geometry, crs).to_crs(epsg4326, tol).boundingbox
+
+
+def eo3_grid_spatial(doc, tol=0.001):
+    """
+    Using doc[grids|crs|geometry] compute EO3 style grid spatial:
+
+    ```
+      extent:
+        lat: {begin=<>, end=<>}
+        lon: {begin=<>, end=<>}
+
+      grid_spatial:
+        projection:
+          spatial_reference: "<crs>"
+          geo_ref_points: {ll: {x:<>, y:<>}, ...}
+          valid_data: {...}
+    ```
+    """
+    grid = doc['grids']['default']
+    crs = doc['crs']
+    geometry = doc.get('geometry')
+
+    if geometry is not None:
+        valid_data = dict(valid_data=geometry)
+    else:
+        valid_data = {}
+
+    oo = dict(grid_spatial=dict(projection={
+        'spatial_reference': crs,
+        'geo_ref_points': grid2ref_points(grid),
+        **valid_data,
+    }))
+
+    bb = eo3_lonlat_bbox(doc, tol=tol)
+    oo['extent'] = dict(
+        lat=dict(begin=bb.bottom, end=bb.top),
+        lon=dict(begin=bb.left, end=bb.right))
+
+    return oo

--- a/libs/index/odc/index/_index.py
+++ b/libs/index/odc/index/_index.py
@@ -120,7 +120,7 @@ def time_range(begin, end, freq='m'):
         t += 1
 
 
-def chop_query_by_time(q: Query, freq: str = 'm') -> Iterator[Query] :
+def chop_query_by_time(q: Query, freq: str = 'm') -> Iterator[Query]:
     """Given a query over longer period of time, chop it up along the time dimension
     into smaller queries each covering a shorter time period (year, month, week or day).
     """

--- a/libs/index/odc/index/_index.py
+++ b/libs/index/odc/index/_index.py
@@ -56,7 +56,9 @@ def parse_doc_stream(doc_stream, on_error=None):
         yield uri, metadata
 
 
-def from_yaml_doc_stream(doc_stream, index, logger=None, **kwargs):
+def from_yaml_doc_stream(doc_stream, index, logger=None,
+                         transform=None,
+                         **kwargs):
     """ returns a sequence of tuples where each tuple is either
 
         (Dataset, None) or (None, error_message)
@@ -66,6 +68,10 @@ def from_yaml_doc_stream(doc_stream, index, logger=None, **kwargs):
             logger.error("Failed to parse: %s", uri)
 
     metadata_stream = parse_doc_stream(doc_stream, on_error=on_parse_error)
+
+    if transform is not None:
+        metadata_stream = map(lambda d: (d[0], transform(d[1])),
+                              metadata_stream)
 
     return from_metadata_stream(metadata_stream, index, **kwargs)
 

--- a/libs/index/odc/index/data/ard_ls5.yaml
+++ b/libs/index/odc/index/data/ard_ls5.yaml
@@ -1,0 +1,166 @@
+name: ga_ls5t_ard_3
+description: Landsat 5 ARD
+metadata_type: eo3
+
+metadata:
+  product:
+    name: ga_ls5t_ard_3
+
+measurements:
+- name: nbar_blue
+  aliases:
+  - nbar_band01
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_green
+  aliases:
+  - nbar_band02
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbar_red
+  aliases:
+  - nbar_band03
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_nir
+  aliases:
+  - nbar_band04
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbar_swir_1
+  aliases:
+  - nbar_band05
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_swir_2
+  aliases:
+  - nbar_band07
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_blue
+  aliases:
+  - nbart_band01
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_green
+  aliases:
+    - nbart_band02
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_red
+  aliases:
+  - nbart_band03
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbart_nir
+  aliases:
+    - nbart_band04
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_swir_1
+  aliases:
+    - nbart_band05
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbart_swir_2
+  aliases:
+    - nbart_band07
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: oa_fmask
+  aliases:
+      - fmask
+  dtype: uint8
+  nodata: 0
+  units: '1'
+  flags_definition:
+    fmask:
+      bits: [0, 1, 2, 3, 4, 5, 6, 7]
+      description: Fmask
+      values:
+        '0': nodata
+        '1': valid
+        '2': cloud
+        '3': shadow
+        '4': snow
+        '5': water
+- name: oa_nbar_contiguity
+  dtype: uint8
+  nodata: 255
+  units: '1'
+  flags_definition:
+    contiguous:
+      bits: [0]
+      values:
+        '1': True
+        '0': False
+- name: oa_nbart_contiguity
+  dtype: uint8
+  nodata: 255
+  units: '1'
+  flags_definition:
+    contiguous:
+      bits: [0]
+      values:
+        '1': True
+        '0': False
+- name: oa_azimuthal_exiting
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_azimuthal_incident
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_combined_terrain_shadow
+  dtype: uint8
+  nodata: -999
+  units: '1'
+- name: oa_exiting_angle
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_incident_angle
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_relative_azimuth
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_relative_slope
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_satellite_azimuth
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_satellite_view
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_solar_azimuth
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_solar_zenith
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_time_delta
+  dtype: float32
+  nodata: .nan
+  units: '1'

--- a/libs/index/odc/index/data/ard_ls7.yaml
+++ b/libs/index/odc/index/data/ard_ls7.yaml
@@ -1,0 +1,180 @@
+name: ga_ls7e_ard_3
+description: Landsat 7 ARD
+metadata_type: eo3
+
+metadata:
+  product:
+    name: ga_ls7e_ard_3
+
+measurements:
+- name: nbar_blue
+  aliases:
+  - nbar_band01
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_green
+  aliases:
+  - nbar_band02
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbar_red
+  aliases:
+  - nbar_band03
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_nir
+  aliases:
+  - nbar_band04
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbar_swir_1
+  aliases:
+  - nbar_band05
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_swir_2
+  aliases:
+  - nbar_band07
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_panchromatic
+  aliases:
+  - nbar_band08
+  dtype: int16
+  nodata: -999
+  units: '1'
+
+- name: nbart_blue
+  aliases:
+  - nbart_band01
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_green
+  aliases:
+    - nbart_band02
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_red
+  aliases:
+  - nbart_band03
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbart_nir
+  aliases:
+    - nbart_band04
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_swir_1
+  aliases:
+    - nbart_band05
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbart_swir_2
+  aliases:
+    - nbart_band07
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_panchromatic
+  aliases:
+  - nbart_band08
+  dtype: int16
+  nodata: -999
+  units: '1'
+
+- name: oa_fmask
+  aliases:
+      - fmask
+  dtype: uint8
+  nodata: 0
+  units: '1'
+  flags_definition:
+    fmask:
+      bits: [0, 1, 2, 3, 4, 5, 6, 7]
+      description: Fmask
+      values:
+        '0': nodata
+        '1': valid
+        '2': cloud
+        '3': shadow
+        '4': snow
+        '5': water
+- name: oa_nbar_contiguity
+  dtype: uint8
+  nodata: 255
+  units: '1'
+  flags_definition:
+    contiguous:
+      bits: [0]
+      values:
+        '1': True
+        '0': False
+- name: oa_nbart_contiguity
+  dtype: uint8
+  nodata: 255
+  units: '1'
+  flags_definition:
+    contiguous:
+      bits: [0]
+      values:
+        '1': True
+        '0': False
+- name: oa_azimuthal_exiting
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_azimuthal_incident
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_combined_terrain_shadow
+  dtype: uint8
+  nodata: -999
+  units: '1'
+- name: oa_exiting_angle
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_incident_angle
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_relative_azimuth
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_relative_slope
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_satellite_azimuth
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_satellite_view
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_solar_azimuth
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_solar_zenith
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_time_delta
+  dtype: float32
+  nodata: .nan
+  units: '1'

--- a/libs/index/odc/index/data/ard_ls8.yaml
+++ b/libs/index/odc/index/data/ard_ls8.yaml
@@ -1,0 +1,192 @@
+name: ga_ls8c_ard_3
+description: Landsat 8 ARD
+metadata_type: eo3
+
+metadata:
+  product:
+    name: ga_ls8c_ard_3
+
+measurements:
+- name: nbar_coastal_aerosol
+  aliases:
+  - nbar_band01
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_blue
+  aliases:
+  - nbar_band02
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_green
+  aliases:
+  - nbar_band03
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbar_red
+  aliases:
+  - nbar_band04
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_nir
+  aliases:
+  - nbar_band05
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbar_swir_1
+  aliases:
+  - nbar_band06
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_swir_2
+  aliases:
+  - nbar_band07
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbar_panchromatic
+  aliases:
+  - nbar_band08
+  dtype: int16
+  nodata: -999
+  units: '1'
+
+- name: nbart_coastal_aerosol
+  aliases:
+  - nbart_band01
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_blue
+  aliases:
+  - nbart_band02
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_green
+  aliases:
+    - nbart_band03
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_red
+  aliases:
+  - nbart_band04
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbart_nir
+  aliases:
+    - nbart_band05
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_swir_1
+  aliases:
+    - nbart_band06
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name:  nbart_swir_2
+  aliases:
+    - nbart_band07
+  dtype: int16
+  nodata: -999
+  units: '1'
+- name: nbart_panchromatic
+  aliases:
+  - nbart_band08
+  dtype: int16
+  nodata: -999
+  units: '1'
+
+- name: oa_fmask
+  aliases:
+      - fmask
+  dtype: uint8
+  nodata: 0
+  units: '1'
+  flags_definition:
+    fmask:
+      bits: [0, 1, 2, 3, 4, 5, 6, 7]
+      description: Fmask
+      values:
+        '0': nodata
+        '1': valid
+        '2': cloud
+        '3': shadow
+        '4': snow
+        '5': water
+- name: oa_nbar_contiguity
+  dtype: uint8
+  nodata: 255
+  units: '1'
+  flags_definition:
+    contiguous:
+      bits: [0]
+      values:
+        '1': True
+        '0': False
+- name: oa_nbart_contiguity
+  dtype: uint8
+  nodata: 255
+  units: '1'
+  flags_definition:
+    contiguous:
+      bits: [0]
+      values:
+        '1': True
+        '0': False
+- name: oa_azimuthal_exiting
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_azimuthal_incident
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_combined_terrain_shadow
+  dtype: uint8
+  nodata: -999
+  units: '1'
+- name: oa_exiting_angle
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_incident_angle
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_relative_azimuth
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_relative_slope
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_satellite_azimuth
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_satellite_view
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_solar_azimuth
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_solar_zenith
+  dtype: float32
+  nodata: .nan
+  units: '1'
+- name: oa_time_delta
+  dtype: float32
+  nodata: .nan
+  units: '1'

--- a/libs/index/odc/index/data/metadata_eo3.yaml
+++ b/libs/index/odc/index/data/metadata_eo3.yaml
@@ -71,13 +71,6 @@ dataset:
     #
     # But MetadataType does not support integer index keys, so...
     #   BoundingBox: [lon.begin, lat.begin, lon.end, lat.end]
-    lat:
-      description: Latitude range
-      type: double-range
-      min_offset:
-        - ['extent', 'lat', 'begin']
-      max_offset:
-        - ['extent', 'lat', 'end']
 
     lon:
       description: Longitude range
@@ -86,3 +79,12 @@ dataset:
         - ['extent', 'lon', 'begin']
       max_offset:
         - ['extent', 'lon', 'end']
+
+    lat:
+      description: Latitude range
+      type: double-range
+      min_offset:
+        - ['extent', 'lat', 'begin']
+      max_offset:
+        - ['extent', 'lat', 'end']
+

--- a/libs/index/odc/index/data/metadata_eo3.yaml
+++ b/libs/index/odc/index/data/metadata_eo3.yaml
@@ -30,7 +30,7 @@ dataset:
         In general it is a unique string identifier that datasets covering roughly
         the same spatial region share.
 
-      offset: ['properties', 'odc:reference_code']
+      offset: ['properties', 'odc:region_code']
 
     dataset_maturity:
       description: One of - final|interim|nrt  (near real time)


### PR DESCRIPTION
New command line option `--eo3` that will deal correctly with the new style metadata.

Computes `grid_spatial` and `extent` before creating Dataset objects to be added to the DB

Limitations:
- lineage support is not implemented


